### PR TITLE
[PIZ-1] - Add GET method to retrieve all sizes from SizeController

### DIFF
--- a/app/services/size.py
+++ b/app/services/size.py
@@ -28,3 +28,10 @@ def get_size_by_id(_id: int):
     response = size if not error else {'error': error}
     status_code = 200 if size else 404 if not error else 400
     return jsonify(response), status_code
+
+@size.route('/', methods=GET)
+def get_all_sizes():
+    sizes, error = SizeController.get_all()
+    response = sizes if not error else {'error': error}
+    status_code = 200 if sizes else 404 if not error else 400
+    return jsonify(response), status_code


### PR DESCRIPTION
#### Description
This commit adds a new method to the SizeController to retrieve all sizes from the database. Previously, the API only allowed creating, updating, and retrieving a single size by ID. This caused a bug where the application couldn't complete the registration of orders due to this missing endpoint.

#### Related Tickets
[PIZ-1](https://trello.com/c/euzXGcp7/1-piz1-i-cant-create-an-order-bug)